### PR TITLE
Add add-hook and add-block scripts to CLI and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ your-registry/
 
 ## Next Steps
 
-1. **Add components** — Edit `registry.json` and add component files under `registry/<style>/`.
+1. **Add components, hooks, and blocks** — Use `add-component`, `add-hook`, or `add-block`, or edit `registry.json` and add files under `registry/<style>/`.
 2. **Build** — Run `npm run registry:build` (or equivalent) to compile the registry.
 3. **Local testing** — Use the create-test-app command (see below).
 4. **Deploy** — Host the built `public/r/` output where your homepage URL points.
@@ -100,7 +100,9 @@ Full details: [shadcn Registry Docs](https://ui.shadcn.com/docs/registry)
 |---------|-------------|
 | `bun start` | Run the create-shadcn-registry CLI |
 | `bun run add-component` | Add a new component to an existing registry |
-| `bun run remove-component` | Remove a component from the registry |
+| `bun run add-hook` | Add a new hook to an existing registry |
+| `bun run add-block` | Add a new block to an existing registry |
+| `bun run remove-component` | Remove a component, hook, or block from the registry |
 | `bun run create-test-app` | Create a test Next.js app and add registry components |
 
 ### add-component
@@ -133,6 +135,66 @@ npx create-shadcn-registry add-component --component-name my-component --registr
 | `--style` | `new-york` or `default` |
 | `--dependencies` | Comma-separated npm packages (merged with defaults: `class-variance-authority`) |
 
+### add-hook
+
+Add a standalone React hook to your registry:
+
+```bash
+npx create-shadcn-registry add-hook
+# or
+bun run add-hook
+```
+
+You'll be prompted for:
+
+- **Registry folder** — Path to the folder containing `registry.json`
+- **Hook name** — Use `use-<name>` format (e.g. `use-my-hook`)
+- **Style** — New York or Default
+
+The command creates a hook file at `registry/<style>/hooks/<hook-name>.ts` and updates `registry.json`.
+
+Pass flags to skip prompts:
+```bash
+npx create-shadcn-registry add-hook --hook-name use-my-hook --registry-folder . --style new-york
+```
+
+| Flag | Description |
+|------|-------------|
+| `--hook-name` | Hook name in use-<name> format |
+| `--registry-folder` | Path to registry (default: `.`) |
+| `--style` | `new-york` or `default` |
+| `--dependencies` | Comma-separated npm packages |
+
+### add-block
+
+Add a block (complex component with multiple files) to your registry:
+
+```bash
+npx create-shadcn-registry add-block
+# or
+bun run add-block
+```
+
+You'll be prompted for:
+
+- **Registry folder** — Path to the folder containing `registry.json`
+- **Block name** — kebab-case (e.g. `my-block`)
+- **Style** — New York or Default
+
+The command creates a block folder at `registry/<style>/blocks/<block-name>/` with a component and hook file, and updates `registry.json`.
+
+Pass flags to skip prompts:
+```bash
+npx create-shadcn-registry add-block --block-name my-block --registry-folder . --style new-york
+```
+
+| Flag | Description |
+|------|-------------|
+| `--block-name` | kebab-case block name |
+| `--registry-folder` | Path to registry (default: `.`) |
+| `--style` | `new-york` or `default` |
+| `--dependencies` | Comma-separated npm packages |
+
 ### remove-component
 
 From a registry project (or with the registry folder path), run:
@@ -146,9 +208,9 @@ bun run remove-component
 You'll be prompted for:
 
 - **Registry folder** — Path to the folder containing `registry.json`
-- **Component to remove** — Select from existing components in the registry
+- **Component to remove** — Select from existing components, hooks, or blocks in the registry
 
-The command deletes the component file(s) and updates `registry.json`.
+The command deletes the item's file(s) and updates `registry.json`.
 
 Pass flags to skip prompts:
 ```bash

--- a/README.md
+++ b/README.md
@@ -102,7 +102,9 @@ Full details: [shadcn Registry Docs](https://ui.shadcn.com/docs/registry)
 | `bun run add-component` | Add a new component to an existing registry |
 | `bun run add-hook` | Add a new hook to an existing registry |
 | `bun run add-block` | Add a new block to an existing registry |
-| `bun run remove-component` | Remove a component, hook, or block from the registry |
+| `bun run remove-component` | Remove a component from the registry |
+| `bun run remove-hook` | Remove a hook from the registry |
+| `bun run remove-block` | Remove a block from the registry |
 | `bun run create-test-app` | Create a test Next.js app and add registry components |
 
 ### add-component
@@ -197,7 +199,7 @@ npx create-shadcn-registry add-block --block-name my-block --registry-folder . -
 
 ### remove-component
 
-From a registry project (or with the registry folder path), run:
+Remove a UI component from your registry:
 
 ```bash
 npx create-shadcn-registry remove-component
@@ -208,9 +210,9 @@ bun run remove-component
 You'll be prompted for:
 
 - **Registry folder** — Path to the folder containing `registry.json`
-- **Component to remove** — Select from existing components, hooks, or blocks in the registry
+- **Component to remove** — Select from existing components
 
-The command deletes the item's file(s) and updates `registry.json`.
+The command deletes the component file(s) and updates `registry.json`.
 
 Pass flags to skip prompts:
 ```bash
@@ -220,6 +222,56 @@ npx create-shadcn-registry remove-component --component button --registry-folder
 | Flag | Description |
 |------|-------------|
 | `--component` | Component name to remove |
+| `--registry-folder` | Path to registry (default: `.`) |
+
+### remove-hook
+
+Remove a hook from your registry:
+
+```bash
+npx create-shadcn-registry remove-hook
+# or
+bun run remove-hook
+```
+
+You'll be prompted for:
+
+- **Registry folder** — Path to the folder containing `registry.json`
+- **Hook to remove** — Select from existing hooks
+
+Pass flags to skip prompts:
+```bash
+npx create-shadcn-registry remove-hook --hook use-my-hook --registry-folder .
+```
+
+| Flag | Description |
+|------|-------------|
+| `--hook` | Hook name to remove |
+| `--registry-folder` | Path to registry (default: `.`) |
+
+### remove-block
+
+Remove a block from your registry:
+
+```bash
+npx create-shadcn-registry remove-block
+# or
+bun run remove-block
+```
+
+You'll be prompted for:
+
+- **Registry folder** — Path to the folder containing `registry.json`
+- **Block to remove** — Select from existing blocks
+
+Pass flags to skip prompts:
+```bash
+npx create-shadcn-registry remove-block --block my-block --registry-folder .
+```
+
+| Flag | Description |
+|------|-------------|
+| `--block` | Block name to remove |
 | `--registry-folder` | Path to registry (default: `.`) |
 
 ### create-test-app

--- a/bin/add-block.js
+++ b/bin/add-block.js
@@ -137,14 +137,23 @@ if (flags.style != null) {
 
 const registryPath = resolve(process.cwd(), registryFolder);
 const registryJsonPath = join(registryPath, "registry.json");
-const blockDir = join(registryPath, "registry", styleName, "blocks", blockName);
-const componentFilePath = join(blockDir, `${blockName}.tsx`);
-const hookFilePath = join(blockDir, `use-${blockName}.ts`);
-
 if (!existsSync(registryJsonPath)) {
   console.error("Error: registry.json not found");
   process.exit(1);
 }
+
+const registry = JSON.parse(readFileSync(registryJsonPath, "utf-8"));
+registry.items = registry.items || [];
+if (registry.items.some((i) => i.name === blockName)) {
+  console.error(
+    `Error: Block "${blockName}" already exists in registry. Remove it first or choose a different name.`,
+  );
+  process.exit(1);
+}
+
+const blockDir = join(registryPath, "registry", styleName, "blocks", blockName);
+const componentFilePath = join(blockDir, `${blockName}.tsx`);
+const hookFilePath = join(blockDir, `use-${blockName}.ts`);
 
 if (existsSync(componentFilePath)) {
   cancel(`Block already exists at ${blockDir}`);
@@ -166,7 +175,6 @@ mkdirSync(blockDir, { recursive: true });
 writeFileSync(componentFilePath, blockComponentContent);
 writeFileSync(hookFilePath, blockHookContent);
 
-const registry = JSON.parse(readFileSync(registryJsonPath, "utf-8"));
 const componentPath = `registry/${styleName}/blocks/${blockName}/${blockName}.tsx`;
 const hookPath = `registry/${styleName}/blocks/${blockName}/use-${blockName}.ts`;
 
@@ -200,7 +208,6 @@ const newItem = {
   ],
 };
 
-registry.items = registry.items || [];
 registry.items.push(newItem);
 
 writeFileSync(registryJsonPath, JSON.stringify(registry, null, 2));

--- a/bin/add-block.js
+++ b/bin/add-block.js
@@ -1,0 +1,210 @@
+#!/usr/bin/env node
+
+import {
+  intro,
+  outro,
+  text,
+  select,
+  isCancel,
+  cancel,
+} from "@clack/prompts";
+import { resolve, join } from "node:path";
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from "node:fs";
+import { parseArgs } from "./parse-args.js";
+
+function handleCancel(value) {
+  if (isCancel(value)) {
+    cancel("Operation cancelled.");
+    process.exit(0);
+  }
+}
+
+function toPascalCase(str) {
+  return str
+    .split("-")
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1).toLowerCase())
+    .join("");
+}
+
+function validateBlockName(value) {
+  if (value.length === 0) return "Block name is required!";
+  if (!/^[a-z][a-z0-9-]*[a-z0-9]?$/.test(value))
+    return "Use kebab-case (e.g. my-block)";
+  return undefined;
+}
+
+const BLOCK_COMPONENT_TEMPLATE = `"use client"
+
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+import { use{{BLOCK_PASCAL}} } from "./use-{{BLOCK_NAME}}"
+
+export function {{BLOCK_PASCAL}}({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  const { value, toggle } = use{{BLOCK_PASCAL}}()
+
+  return (
+    <div
+      data-slot="{{BLOCK_NAME}}"
+      className={cn("rounded-lg border p-4", className)}
+      {...props}
+    >
+      <button
+        type="button"
+        onClick={toggle}
+        className="text-sm font-medium"
+      >
+        Toggle: {value ? "ON" : "OFF"}
+      </button>
+    </div>
+  )
+}
+`;
+
+const BLOCK_HOOK_TEMPLATE = `"use client"
+
+import * as React from "react"
+
+export function use{{BLOCK_PASCAL}}() {
+  const [value, setValue] = React.useState(false)
+
+  const toggle = React.useCallback(() => {
+    setValue((v) => !v)
+  }, [])
+
+  return { value, setValue, toggle }
+}
+`;
+
+const { flags } = parseArgs();
+
+intro("add-block — Add a block to your registry");
+
+let registryFolder;
+if (flags["registry-folder"] != null) {
+  registryFolder = flags["registry-folder"];
+} else {
+  registryFolder = await text({
+    message: "Folder containing the registry?",
+    placeholder: ".",
+    validate(value) {
+      const p = resolve(process.cwd(), value);
+      if (!existsSync(join(p, "registry.json"))) {
+        return "registry.json not found in that folder";
+      }
+    },
+  });
+  handleCancel(registryFolder);
+}
+
+let blockName;
+if (flags["block-name"] != null) {
+  blockName = flags["block-name"];
+  const err = validateBlockName(blockName);
+  if (err) {
+    console.error(`Error: ${err}`);
+    process.exit(1);
+  }
+} else {
+  blockName = await text({
+    message: "Block name (kebab-case)?",
+    placeholder: "my-block",
+    validate: validateBlockName,
+  });
+  handleCancel(blockName);
+}
+
+let styleName;
+if (flags.style != null) {
+  styleName = flags.style;
+  if (!["new-york", "default"].includes(styleName)) {
+    console.error(`Error: --style must be "new-york" or "default"`);
+    process.exit(1);
+  }
+} else {
+  styleName = await select({
+    message: "Which style?",
+    options: [
+      { value: "new-york", label: "New York" },
+      { value: "default", label: "Default" },
+    ],
+  });
+  handleCancel(styleName);
+}
+
+const registryPath = resolve(process.cwd(), registryFolder);
+const registryJsonPath = join(registryPath, "registry.json");
+const blockDir = join(registryPath, "registry", styleName, "blocks", blockName);
+const componentFilePath = join(blockDir, `${blockName}.tsx`);
+const hookFilePath = join(blockDir, `use-${blockName}.ts`);
+
+if (!existsSync(registryJsonPath)) {
+  console.error("Error: registry.json not found");
+  process.exit(1);
+}
+
+if (existsSync(componentFilePath)) {
+  cancel(`Block already exists at ${blockDir}`);
+  process.exit(1);
+}
+
+const pascalName = toPascalCase(blockName);
+const blockComponentContent = BLOCK_COMPONENT_TEMPLATE.replace(
+  /\{\{BLOCK_PASCAL\}\}/g,
+  pascalName
+).replace(/\{\{BLOCK_NAME\}\}/g, blockName);
+
+const blockHookContent = BLOCK_HOOK_TEMPLATE.replace(
+  /\{\{BLOCK_PASCAL\}\}/g,
+  pascalName
+);
+
+mkdirSync(blockDir, { recursive: true });
+writeFileSync(componentFilePath, blockComponentContent);
+writeFileSync(hookFilePath, blockHookContent);
+
+const registry = JSON.parse(readFileSync(registryJsonPath, "utf-8"));
+const componentPath = `registry/${styleName}/blocks/${blockName}/${blockName}.tsx`;
+const hookPath = `registry/${styleName}/blocks/${blockName}/use-${blockName}.ts`;
+
+const DEFAULT_DEPS = [];
+let dependencies = [...DEFAULT_DEPS];
+if (
+  typeof flags.dependencies === "string" &&
+  flags.dependencies.trim() !== ""
+) {
+  const extra = flags.dependencies
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+  dependencies = [...new Set([...DEFAULT_DEPS, ...extra])];
+}
+
+const newItem = {
+  name: blockName,
+  type: "registry:block",
+  dependencies,
+  registryDependencies: [],
+  files: [
+    {
+      path: componentPath,
+      type: "registry:component",
+    },
+    {
+      path: hookPath,
+      type: "registry:hook",
+    },
+  ],
+};
+
+registry.items = registry.items || [];
+registry.items.push(newItem);
+
+writeFileSync(registryJsonPath, JSON.stringify(registry, null, 2));
+
+outro(
+  `Added block ${blockName} at registry/${styleName}/blocks/${blockName}/. Run \`registry:build\` to rebuild.`
+);

--- a/bin/add-component.js
+++ b/bin/add-component.js
@@ -158,17 +158,6 @@ if (existsSync(componentFilePath)) {
   process.exit(1);
 }
 
-const pascalName = toPascalCase(componentName);
-const slotName = componentName;
-
-const componentContent = COMPONENT_TEMPLATE.replace(
-  /\{\{COMPONENT_NAME\}\}/g,
-  pascalName
-).replace(/\{\{SLOT_NAME\}\}/g, slotName);
-
-mkdirSync(componentDir, { recursive: true });
-writeFileSync(componentFilePath, componentContent);
-
 const filePath = `registry/${styleName}/ui/${componentName}.tsx`;
 
 // Default deps for the component template (CVA + cn from utils)
@@ -199,9 +188,23 @@ const newItem = {
 };
 
 registry.items.push(newItem);
-
 writeFileSync(registryJsonPath, JSON.stringify(registry, null, 2));
 
+try {
+  const pascalName = toPascalCase(componentName);
+  const slotName = componentName;
+  const componentContent = COMPONENT_TEMPLATE.replace(
+    /\{\{COMPONENT_NAME\}\}/g,
+    pascalName,
+  ).replace(/\{\{SLOT_NAME\}\}/g, slotName);
+  mkdirSync(componentDir, { recursive: true });
+  writeFileSync(componentFilePath, componentContent);
+} catch (err) {
+  registry.items = registry.items.filter((i) => i.name !== componentName);
+  writeFileSync(registryJsonPath, JSON.stringify(registry, null, 2));
+  throw err;
+}
+
 outro(
-  `Added ${componentName} at ${filePath}. Run \`registry:build\` to rebuild.`
+  `Added ${componentName} at ${filePath}. Run \`registry:build\` to rebuild.`,
 );

--- a/bin/add-component.js
+++ b/bin/add-component.js
@@ -134,14 +134,22 @@ if (flags.style != null) {
   handleCancel(styleName);
 }
 
-const regPath = resolve(process.cwd(), registryFolder);
-if (!existsSync(join(regPath, "registry.json"))) {
+const registryPath = resolve(process.cwd(), registryFolder);
+const registryJsonPath = join(registryPath, "registry.json");
+if (!existsSync(registryJsonPath)) {
   console.error("Error: registry.json not found in that folder");
   process.exit(1);
 }
 
-const registryPath = resolve(process.cwd(), registryFolder);
-const registryJsonPath = join(registryPath, "registry.json");
+const registry = JSON.parse(readFileSync(registryJsonPath, "utf-8"));
+registry.items = registry.items || [];
+if (registry.items.some((i) => i.name === componentName)) {
+  console.error(
+    `Error: Component "${componentName}" already exists in registry. Remove it first or choose a different name.`,
+  );
+  process.exit(1);
+}
+
 const componentDir = join(registryPath, "registry", styleName, "ui");
 const componentFilePath = join(componentDir, `${componentName}.tsx`);
 
@@ -161,7 +169,6 @@ const componentContent = COMPONENT_TEMPLATE.replace(
 mkdirSync(componentDir, { recursive: true });
 writeFileSync(componentFilePath, componentContent);
 
-const registry = JSON.parse(readFileSync(registryJsonPath, "utf-8"));
 const filePath = `registry/${styleName}/ui/${componentName}.tsx`;
 
 // Default deps for the component template (CVA + cn from utils)
@@ -191,7 +198,6 @@ const newItem = {
   ],
 };
 
-registry.items = registry.items || [];
 registry.items.push(newItem);
 
 writeFileSync(registryJsonPath, JSON.stringify(registry, null, 2));

--- a/bin/add-hook.js
+++ b/bin/add-hook.js
@@ -131,16 +131,6 @@ if (existsSync(hookFilePath)) {
   process.exit(1);
 }
 
-const hookFunctionName = toHookFunctionName(hookName);
-
-const hookContent = HOOK_TEMPLATE.replace(
-  /\{\{HOOK_NAME\}\}/g,
-  hookFunctionName
-);
-
-mkdirSync(hookDir, { recursive: true });
-writeFileSync(hookFilePath, hookContent);
-
 const filePath = `registry/${styleName}/hooks/${hookName}.ts`;
 
 const DEFAULT_DEPS = [];
@@ -170,7 +160,20 @@ const newItem = {
 };
 
 registry.items.push(newItem);
-
 writeFileSync(registryJsonPath, JSON.stringify(registry, null, 2));
+
+try {
+  const hookFunctionName = toHookFunctionName(hookName);
+  const hookContent = HOOK_TEMPLATE.replace(
+    /\{\{HOOK_NAME\}\}/g,
+    hookFunctionName,
+  );
+  mkdirSync(hookDir, { recursive: true });
+  writeFileSync(hookFilePath, hookContent);
+} catch (err) {
+  registry.items = registry.items.filter((i) => i.name !== hookName);
+  writeFileSync(registryJsonPath, JSON.stringify(registry, null, 2));
+  throw err;
+}
 
 outro(`Added ${hookName} at ${filePath}. Run \`registry:build\` to rebuild.`);

--- a/bin/add-hook.js
+++ b/bin/add-hook.js
@@ -109,13 +109,22 @@ if (flags.style != null) {
 
 const registryPath = resolve(process.cwd(), registryFolder);
 const registryJsonPath = join(registryPath, "registry.json");
-const hookDir = join(registryPath, "registry", styleName, "hooks");
-const hookFilePath = join(hookDir, `${hookName}.ts`);
-
 if (!existsSync(registryJsonPath)) {
   console.error("Error: registry.json not found");
   process.exit(1);
 }
+
+const registry = JSON.parse(readFileSync(registryJsonPath, "utf-8"));
+registry.items = registry.items || [];
+if (registry.items.some((i) => i.name === hookName)) {
+  console.error(
+    `Error: Hook "${hookName}" already exists in registry. Remove it first or choose a different name.`,
+  );
+  process.exit(1);
+}
+
+const hookDir = join(registryPath, "registry", styleName, "hooks");
+const hookFilePath = join(hookDir, `${hookName}.ts`);
 
 if (existsSync(hookFilePath)) {
   cancel(`Hook already exists at ${hookFilePath}`);
@@ -132,7 +141,6 @@ const hookContent = HOOK_TEMPLATE.replace(
 mkdirSync(hookDir, { recursive: true });
 writeFileSync(hookFilePath, hookContent);
 
-const registry = JSON.parse(readFileSync(registryJsonPath, "utf-8"));
 const filePath = `registry/${styleName}/hooks/${hookName}.ts`;
 
 const DEFAULT_DEPS = [];
@@ -161,7 +169,6 @@ const newItem = {
   ],
 };
 
-registry.items = registry.items || [];
 registry.items.push(newItem);
 
 writeFileSync(registryJsonPath, JSON.stringify(registry, null, 2));

--- a/bin/add-hook.js
+++ b/bin/add-hook.js
@@ -1,0 +1,169 @@
+#!/usr/bin/env node
+
+import {
+  intro,
+  outro,
+  text,
+  select,
+  isCancel,
+  cancel,
+} from "@clack/prompts";
+import { resolve, join } from "node:path";
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from "node:fs";
+import { parseArgs } from "./parse-args.js";
+
+function handleCancel(value) {
+  if (isCancel(value)) {
+    cancel("Operation cancelled.");
+    process.exit(0);
+  }
+}
+
+function toHookFunctionName(str) {
+  // use-my-hook -> useMyHook
+  return str
+    .split("-")
+    .map((part, i) =>
+      i === 0 ? part : part.charAt(0).toUpperCase() + part.slice(1).toLowerCase()
+    )
+    .join("");
+}
+
+function validateHookName(value) {
+  if (value.length === 0) return "Hook name is required!";
+  if (!/^use-[a-z][a-z0-9-]*[a-z0-9]?$/.test(value))
+    return "Use use-<name> format (e.g. use-my-hook)";
+  return undefined;
+}
+
+const HOOK_TEMPLATE = `"use client"
+
+import * as React from "react"
+
+export function {{HOOK_NAME}}(options?: { defaultValue?: boolean }) {
+  const [value, setValue] = React.useState(options?.defaultValue ?? false)
+
+  const toggle = React.useCallback(() => {
+    setValue((v) => !v)
+  }, [])
+
+  return { value, setValue, toggle }
+}
+`;
+
+const { flags } = parseArgs();
+
+intro("add-hook — Add a hook to your registry");
+
+let registryFolder;
+if (flags["registry-folder"] != null) {
+  registryFolder = flags["registry-folder"];
+} else {
+  registryFolder = await text({
+    message: "Folder containing the registry?",
+    placeholder: ".",
+    validate(value) {
+      const p = resolve(process.cwd(), value);
+      if (!existsSync(join(p, "registry.json"))) {
+        return "registry.json not found in that folder";
+      }
+    },
+  });
+  handleCancel(registryFolder);
+}
+
+let hookName;
+if (flags["hook-name"] != null) {
+  hookName = flags["hook-name"];
+  const err = validateHookName(hookName);
+  if (err) {
+    console.error(`Error: ${err}`);
+    process.exit(1);
+  }
+} else {
+  hookName = await text({
+    message: "Hook name (use-<name>)?",
+    placeholder: "use-my-hook",
+    validate: validateHookName,
+  });
+  handleCancel(hookName);
+}
+
+let styleName;
+if (flags.style != null) {
+  styleName = flags.style;
+  if (!["new-york", "default"].includes(styleName)) {
+    console.error(`Error: --style must be "new-york" or "default"`);
+    process.exit(1);
+  }
+} else {
+  styleName = await select({
+    message: "Which style?",
+    options: [
+      { value: "new-york", label: "New York" },
+      { value: "default", label: "Default" },
+    ],
+  });
+  handleCancel(styleName);
+}
+
+const registryPath = resolve(process.cwd(), registryFolder);
+const registryJsonPath = join(registryPath, "registry.json");
+const hookDir = join(registryPath, "registry", styleName, "hooks");
+const hookFilePath = join(hookDir, `${hookName}.ts`);
+
+if (!existsSync(registryJsonPath)) {
+  console.error("Error: registry.json not found");
+  process.exit(1);
+}
+
+if (existsSync(hookFilePath)) {
+  cancel(`Hook already exists at ${hookFilePath}`);
+  process.exit(1);
+}
+
+const hookFunctionName = toHookFunctionName(hookName);
+
+const hookContent = HOOK_TEMPLATE.replace(
+  /\{\{HOOK_NAME\}\}/g,
+  hookFunctionName
+);
+
+mkdirSync(hookDir, { recursive: true });
+writeFileSync(hookFilePath, hookContent);
+
+const registry = JSON.parse(readFileSync(registryJsonPath, "utf-8"));
+const filePath = `registry/${styleName}/hooks/${hookName}.ts`;
+
+const DEFAULT_DEPS = [];
+let dependencies = [...DEFAULT_DEPS];
+if (
+  typeof flags.dependencies === "string" &&
+  flags.dependencies.trim() !== ""
+) {
+  const extra = flags.dependencies
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+  dependencies = [...new Set([...DEFAULT_DEPS, ...extra])];
+}
+
+const newItem = {
+  name: hookName,
+  type: "registry:hook",
+  dependencies,
+  registryDependencies: [],
+  files: [
+    {
+      path: filePath,
+      type: "registry:hook",
+    },
+  ],
+};
+
+registry.items = registry.items || [];
+registry.items.push(newItem);
+
+writeFileSync(registryJsonPath, JSON.stringify(registry, null, 2));
+
+outro(`Added ${hookName} at ${filePath}. Run \`registry:build\` to rebuild.`);

--- a/bin/index.js
+++ b/bin/index.js
@@ -17,6 +17,14 @@ if (subcommand === "remove-component") {
   await import("./remove-component.js");
   process.exit(0);
 }
+if (subcommand === "remove-hook") {
+  await import("./remove-hook.js");
+  process.exit(0);
+}
+if (subcommand === "remove-block") {
+  await import("./remove-block.js");
+  process.exit(0);
+}
 if (subcommand === "create-test-app") {
   await import("./create-test-app.js");
   process.exit(0);

--- a/bin/index.js
+++ b/bin/index.js
@@ -5,6 +5,14 @@ if (subcommand === "add-component") {
   await import("./add-component.js");
   process.exit(0);
 }
+if (subcommand === "add-hook") {
+  await import("./add-hook.js");
+  process.exit(0);
+}
+if (subcommand === "add-block") {
+  await import("./add-block.js");
+  process.exit(0);
+}
 if (subcommand === "remove-component") {
   await import("./remove-component.js");
   process.exit(0);

--- a/bin/remove-block.js
+++ b/bin/remove-block.js
@@ -8,12 +8,13 @@ import {
   isCancel,
   cancel,
 } from "@clack/prompts";
-import { resolve, join } from "node:path";
+import { resolve, join, dirname } from "node:path";
 import {
   readFileSync,
   writeFileSync,
   existsSync,
   unlinkSync,
+  rmSync,
 } from "node:fs";
 import { parseArgs } from "./parse-args.js";
 
@@ -26,7 +27,7 @@ function handleCancel(value) {
 
 const { flags } = parseArgs();
 
-intro("remove-component — Remove a component from your registry");
+intro("remove-block — Remove a block from your registry");
 
 let registryFolder;
 if (flags["registry-folder"] != null) {
@@ -49,37 +50,35 @@ const registryPath = resolve(process.cwd(), registryFolder);
 const registryJsonPath = join(registryPath, "registry.json");
 const registry = JSON.parse(readFileSync(registryJsonPath, "utf-8"));
 const items = registry.items || [];
-const components = items.filter(
-  (i) => i.type === "registry:ui" || i.type === "registry:component",
-);
+const blocks = items.filter((i) => i.type === "registry:block");
 
-if (components.length === 0) {
-  cancel("No components in registry.");
+if (blocks.length === 0) {
+  cancel("No blocks in registry.");
   process.exit(1);
 }
 
-let componentName;
-if (flags.component != null) {
-  componentName = flags.component;
-  const found = components.find((i) => i.name === componentName);
+let blockName;
+if (flags.block != null) {
+  blockName = flags.block;
+  const found = blocks.find((i) => i.name === blockName);
   if (!found) {
     console.error(
-      `Error: Component "${componentName}" not found. Available: ${components.map((i) => i.name).join(", ")}`,
+      `Error: Block "${blockName}" not found. Available: ${blocks.map((i) => i.name).join(", ")}`,
     );
     process.exit(1);
   }
 } else {
-  componentName = await select({
-    message: "Which component to remove?",
-    options: components.map((item) => ({
+  blockName = await select({
+    message: "Which block to remove?",
+    options: blocks.map((item) => ({
       value: item.name,
       label: item.name,
     })),
   });
-  handleCancel(componentName);
+  handleCancel(blockName);
 }
 
-const item = items.find((i) => i.name === componentName);
+const item = items.find((i) => i.name === blockName);
 const files = item?.files || [];
 
 for (const file of files) {
@@ -93,7 +92,20 @@ for (const file of files) {
   }
 }
 
-registry.items = items.filter((i) => i.name !== componentName);
+// Remove empty block directory (derive path from first file: registry/<style>/blocks/<name>/)
+const firstFile = files[0];
+if (firstFile?.path) {
+  const dir = join(registryPath, dirname(firstFile.path));
+  if (existsSync(dir)) {
+    try {
+      rmSync(dir, { recursive: true });
+    } catch {
+      /* dir may not be empty or already removed */
+    }
+  }
+}
+
+registry.items = items.filter((i) => i.name !== blockName);
 writeFileSync(registryJsonPath, JSON.stringify(registry, null, 2));
 
-outro(`Removed ${componentName}. Run \`registry:build\` to rebuild.`);
+outro(`Removed ${blockName}. Run \`registry:build\` to rebuild.`);

--- a/bin/remove-block.js
+++ b/bin/remove-block.js
@@ -92,7 +92,7 @@ for (const file of files) {
   }
 }
 
-// Remove empty block directory (derive path from first file: registry/<style>/blocks/<name>/)
+// Recursively delete block directory and all contents (derive path from first file: registry/<style>/blocks/<name>/)
 const firstFile = files[0];
 if (firstFile?.path) {
   const dir = join(registryPath, dirname(firstFile.path));

--- a/bin/remove-hook.js
+++ b/bin/remove-hook.js
@@ -26,7 +26,7 @@ function handleCancel(value) {
 
 const { flags } = parseArgs();
 
-intro("remove-component — Remove a component from your registry");
+intro("remove-hook — Remove a hook from your registry");
 
 let registryFolder;
 if (flags["registry-folder"] != null) {
@@ -49,37 +49,35 @@ const registryPath = resolve(process.cwd(), registryFolder);
 const registryJsonPath = join(registryPath, "registry.json");
 const registry = JSON.parse(readFileSync(registryJsonPath, "utf-8"));
 const items = registry.items || [];
-const components = items.filter(
-  (i) => i.type === "registry:ui" || i.type === "registry:component",
-);
+const hooks = items.filter((i) => i.type === "registry:hook");
 
-if (components.length === 0) {
-  cancel("No components in registry.");
+if (hooks.length === 0) {
+  cancel("No hooks in registry.");
   process.exit(1);
 }
 
-let componentName;
-if (flags.component != null) {
-  componentName = flags.component;
-  const found = components.find((i) => i.name === componentName);
+let hookName;
+if (flags.hook != null) {
+  hookName = flags.hook;
+  const found = hooks.find((i) => i.name === hookName);
   if (!found) {
     console.error(
-      `Error: Component "${componentName}" not found. Available: ${components.map((i) => i.name).join(", ")}`,
+      `Error: Hook "${hookName}" not found. Available: ${hooks.map((i) => i.name).join(", ")}`,
     );
     process.exit(1);
   }
 } else {
-  componentName = await select({
-    message: "Which component to remove?",
-    options: components.map((item) => ({
+  hookName = await select({
+    message: "Which hook to remove?",
+    options: hooks.map((item) => ({
       value: item.name,
       label: item.name,
     })),
   });
-  handleCancel(componentName);
+  handleCancel(hookName);
 }
 
-const item = items.find((i) => i.name === componentName);
+const item = items.find((i) => i.name === hookName);
 const files = item?.files || [];
 
 for (const file of files) {
@@ -93,7 +91,7 @@ for (const file of files) {
   }
 }
 
-registry.items = items.filter((i) => i.name !== componentName);
+registry.items = items.filter((i) => i.name !== hookName);
 writeFileSync(registryJsonPath, JSON.stringify(registry, null, 2));
 
-outro(`Removed ${componentName}. Run \`registry:build\` to rebuild.`);
+outro(`Removed ${hookName}. Run \`registry:build\` to rebuild.`);

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
     "add-hook": "node bin/add-hook.js",
     "add-block": "node bin/add-block.js",
     "remove-component": "node bin/remove-component.js",
+    "remove-hook": "node bin/remove-hook.js",
+    "remove-block": "node bin/remove-block.js",
     "create-test-app": "node bin/create-test-app.js"
   },
   "bin": {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
   "scripts": {
     "start": "node bin/index.js",
     "add-component": "node bin/add-component.js",
+    "add-hook": "node bin/add-hook.js",
+    "add-block": "node bin/add-block.js",
     "remove-component": "node bin/remove-component.js",
     "create-test-app": "node bin/create-test-app.js"
   },


### PR DESCRIPTION
Introduced new CLI commands for adding hooks and blocks to the registry. Updated the README to reflect these changes, including usage instructions for the new commands and modifications to existing sections for clarity.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added CLI commands to manage hooks and blocks: add-hook, add-block, remove-hook, and remove-block; support interactive prompts and flags.

* **Documentation**
  * Expanded usage docs with detailed guidance, prompts, flags, file-generation and removal workflows for hooks, blocks, and components.

* **Bug Fixes**
  * Improved component removal flow to correctly filter and identify components before removal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->