### PR TITLE
Add help command and usage instructions to CLI

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -1,6 +1,41 @@
 #!/usr/bin/env node
 
-const subcommand = process.argv[2];
+const HELP = `
+create-shadcn-registry — Scaffold a custom shadcn/ui component registry
+
+USAGE
+  create-shadcn-registry [command] [options]
+  create-shadcn-registry --help | -h
+
+COMMANDS (run from registry folder or pass --registry-folder)
+  add-component    Add a new component
+  add-hook         Add a new hook
+  add-block        Add a new block
+  remove-component Remove a component
+  remove-hook      Remove a hook
+  remove-block     Remove a block
+  create-test-app  Create a test Next.js app with registry components
+
+OPTIONS (scaffolding — when run without a command)
+  --registry-name    Registry identifier (e.g. @name/component)
+  --project-location Where to create the registry
+  --framework        Target framework
+  --style            new-york | default
+  --homepage         URL where the registry will be hosted
+
+EXAMPLES
+  npx create-shadcn-registry
+  npx create-shadcn-registry --registry-name my-ui --style default
+  npx create-shadcn-registry add-component --component-name my-button --style new-york
+`;
+
+const arg = process.argv[2];
+if (arg === "help" || arg === "--help" || arg === "-h") {
+  console.log(HELP.trim());
+  process.exit(0);
+}
+
+const subcommand = arg;
 if (subcommand === "add-component") {
   await import("./add-component.js");
   process.exit(0);


### PR DESCRIPTION
Enhanced the CLI by adding a help command that displays usage instructions for the `create-shadcn-registry` tool. The help text includes available commands, options, and examples for better user guidance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive help documentation support to the CLI tool, allowing users to view detailed usage information and available commands by invoking `--help`, `-h`, or `help` flags from the command line.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->