### PR TITLE
Enhance CLI functionality by integrating writeRegistryExports in add-…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ test/
 node_modules/
 test-app/
 bun.lock
+.DS_Store
+bin/.DS_Store

--- a/bin/add-block.js
+++ b/bin/add-block.js
@@ -18,6 +18,7 @@ import {
   rmdirSync,
 } from "node:fs";
 import { parseArgs } from "./parse-args.js";
+import { writeRegistryExports } from "./generate-registry-exports.js";
 
 function handleCancel(value) {
   if (isCancel(value)) {
@@ -218,6 +219,7 @@ try {
   mkdirSync(blockDir, { recursive: true });
   writeFileSync(componentFilePath, blockComponentContent);
   writeFileSync(hookFilePath, blockHookContent);
+  writeRegistryExports(registryPath);
 } catch (err) {
   if (existsSync(componentFilePath)) unlinkSync(componentFilePath);
   if (existsSync(hookFilePath)) unlinkSync(hookFilePath);

--- a/bin/add-component.js
+++ b/bin/add-component.js
@@ -12,6 +12,7 @@ import { resolve, join, dirname } from "node:path";
 import { readFileSync, writeFileSync, existsSync, mkdirSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { parseArgs } from "./parse-args.js";
+import { writeRegistryExports } from "./generate-registry-exports.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -54,9 +55,16 @@ const {{COMPONENT_NAME}}Variants = cva(
           "border-transparent bg-destructive text-destructive-foreground shadow hover:bg-destructive/80",
         outline: "text-foreground border border-input bg-background",
       },
+      size: {
+        default: "h-9 px-4 py-2",
+        sm: "h-8 rounded-md px-3",
+        lg: "h-10 rounded-md px-8",
+        icon: "size-9",
+      },
     },
     defaultVariants: {
       variant: "default",
+      size: "default",
     },
   }
 )
@@ -64,14 +72,18 @@ const {{COMPONENT_NAME}}Variants = cva(
 function {{COMPONENT_NAME}}({
   className,
   variant,
+  size,
   ...props
-}: React.ComponentProps<"div"> & VariantProps<typeof {{COMPONENT_NAME}}Variants>) {
+}: React.ComponentProps<"button"> &
+  VariantProps<typeof {{COMPONENT_NAME}}Variants>) {
   return (
-    <div
+    <button
       data-slot="{{SLOT_NAME}}"
-      className={cn({{COMPONENT_NAME}}Variants({ variant, className }))}
+      className={cn({{COMPONENT_NAME}}Variants({ variant, size, className }))}
       {...props}
-    />
+    >
+      Customize me
+    </button>
   )
 }
 
@@ -199,6 +211,7 @@ try {
   ).replace(/\{\{SLOT_NAME\}\}/g, slotName);
   mkdirSync(componentDir, { recursive: true });
   writeFileSync(componentFilePath, componentContent);
+  writeRegistryExports(registryPath);
 } catch (err) {
   registry.items = registry.items.filter((i) => i.name !== componentName);
   writeFileSync(registryJsonPath, JSON.stringify(registry, null, 2));

--- a/bin/create.js
+++ b/bin/create.js
@@ -2,6 +2,7 @@ import { execSync } from "node:child_process";
 import { resolve, join, dirname } from "node:path";
 import { readFileSync, writeFileSync, renameSync, existsSync } from "node:fs";
 import { fileURLToPath } from "node:url";
+import { writeRegistryExports } from "./generate-registry-exports.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const REGISTRY_TEMPLATE_URL =
@@ -44,10 +45,11 @@ export async function create({
 
   writeFileSync(registryJsonPath, registryContent);
 
+  writeRegistryExports(targetPath);
+
   const pageTemplatePath = join(__dirname, "templates", "page.tsx");
   const appPagePath = join(targetPath, "app", "page.tsx");
-  let pageContent = readFileSync(pageTemplatePath, "utf-8");
-  pageContent = pageContent.replace(/\{\{STYLE_NAME\}\}/g, styleName);
+  const pageContent = readFileSync(pageTemplatePath, "utf-8");
   writeFileSync(appPagePath, pageContent);
 
   return { targetPath, registryName, framework, styleName, homepage };

--- a/bin/generate-registry-exports.js
+++ b/bin/generate-registry-exports.js
@@ -1,0 +1,60 @@
+/**
+ * Generates registry/exports.ts (barrel file) from registry.json.
+ * Re-exports all UI components and blocks so the page can dynamically load them at request time.
+ */
+
+import { join } from "node:path";
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from "node:fs";
+
+function toPascalCase(str) {
+  return str
+    .split("-")
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1).toLowerCase())
+    .join("");
+}
+
+/**
+ * @param {string} registryPath - Absolute path to folder containing registry.json
+ */
+export function writeRegistryExports(registryPath) {
+  const registryJsonPath = join(registryPath, "registry.json");
+  if (!existsSync(registryJsonPath)) {
+    throw new Error(`registry.json not found at ${registryJsonPath}`);
+  }
+
+  const registry = JSON.parse(readFileSync(registryJsonPath, "utf-8"));
+  const items = registry.items || [];
+  const renderableItems = items.filter(
+    (i) => i.type === "registry:ui" || i.type === "registry:block"
+  );
+
+  const exportsDir = join(registryPath, "registry");
+  mkdirSync(exportsDir, { recursive: true });
+  const barrelPath = join(exportsDir, "exports.ts");
+
+  if (renderableItems.length === 0) {
+    writeFileSync(
+      barrelPath,
+      `// Auto-generated from registry.json - do not edit manually
+export {}
+`
+    );
+    return;
+  }
+
+  const exportLines = renderableItems.map((item) => {
+    const firstFile = item.files?.[0];
+    if (!firstFile?.path) return null;
+    const componentName = toPascalCase(item.name);
+    const relPath = firstFile.path
+      .replace(/^registry\//, "")
+      .replace(/\.(tsx?|jsx?)$/, "");
+    return `export { ${componentName} } from "./${relPath}"`;
+  }).filter(Boolean);
+
+  const content = `// Auto-generated from registry.json - do not edit manually
+${exportLines.join("\n")}
+`;
+
+  writeFileSync(barrelPath, content);
+}

--- a/bin/index.js
+++ b/bin/index.js
@@ -8,7 +8,7 @@ USAGE
   create-shadcn-registry --help | -h
 
 COMMANDS (run from registry folder or pass --registry-folder)
-  add-component    Add a new component
+  add-component    Add a new component (button-style starter)
   add-hook         Add a new hook
   add-block        Add a new block
   remove-component Remove a component

--- a/bin/remove-block.js
+++ b/bin/remove-block.js
@@ -17,6 +17,7 @@ import {
   rmSync,
 } from "node:fs";
 import { parseArgs } from "./parse-args.js";
+import { writeRegistryExports } from "./generate-registry-exports.js";
 
 function handleCancel(value) {
   if (isCancel(value)) {
@@ -107,5 +108,6 @@ if (firstFile?.path) {
 
 registry.items = items.filter((i) => i.name !== blockName);
 writeFileSync(registryJsonPath, JSON.stringify(registry, null, 2));
+writeRegistryExports(registryPath);
 
 outro(`Removed ${blockName}. Run \`registry:build\` to rebuild.`);

--- a/bin/remove-component.js
+++ b/bin/remove-component.js
@@ -16,6 +16,7 @@ import {
   unlinkSync,
 } from "node:fs";
 import { parseArgs } from "./parse-args.js";
+import { writeRegistryExports } from "./generate-registry-exports.js";
 
 function handleCancel(value) {
   if (isCancel(value)) {
@@ -95,5 +96,6 @@ for (const file of files) {
 
 registry.items = items.filter((i) => i.name !== componentName);
 writeFileSync(registryJsonPath, JSON.stringify(registry, null, 2));
+writeRegistryExports(registryPath);
 
 outro(`Removed ${componentName}. Run \`registry:build\` to rebuild.`);

--- a/bin/templates/page.tsx
+++ b/bin/templates/page.tsx
@@ -1,27 +1,240 @@
-import { Button } from "@/registry/{{STYLE_NAME}}/ui/button"
+import type React from "react";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import Link from "next/link";
+import * as Registry from "@/registry/exports";
 
-export default function Home() {
-  return (
-    <div className="max-w-3xl mx-auto flex flex-col min-h-svh px-4 py-8 gap-8">
-      <header className="flex flex-col gap-1">
-        <h1 className="text-3xl font-bold tracking-tight">Custom Registry</h1>
-        <p className="text-muted-foreground">
-          A custom registry for distributing code using shadcn.
-        </p>
-      </header>
-      <main className="flex flex-col flex-1 gap-8">
-        <div className="flex flex-col gap-4 border rounded-lg p-4 min-h-[200px]">
-          <h2 className="text-sm text-muted-foreground">Button component</h2>
-          <div className="flex flex-wrap items-center justify-center gap-4">
-            <Button>Default</Button>
-            <Button variant="secondary">Secondary</Button>
-            <Button variant="outline">Outline</Button>
-            <Button variant="ghost">Ghost</Button>
-            <Button variant="destructive">Destructive</Button>
-            <Button variant="link">Link</Button>
-          </div>
+type RegistryItem = {
+  name: string;
+  type: string;
+};
+
+type SearchParams = Record<string, string | string[] | undefined>;
+
+function toPascalCase(str: string) {
+  return str
+    .split("-")
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1).toLowerCase())
+    .join("");
+}
+
+function formatTitle(str: string) {
+  return str
+    .replace(/-/g, " ")
+    .replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+function getBentoSpan(index: number) {
+  const spans = [
+    "md:col-span-2 md:row-span-2",
+    "md:col-span-1 md:row-span-1",
+    "md:col-span-1 md:row-span-1",
+    "md:col-span-2 md:row-span-1",
+    "md:col-span-1 md:row-span-1",
+  ];
+  return spans[index % spans.length];
+}
+
+export default async function Home({
+  searchParams,
+}: {
+  searchParams?: SearchParams | Promise<SearchParams>;
+}) {
+  const registryPath = join(process.cwd(), "registry.json");
+  const resolvedSearchParams = searchParams ? await searchParams : undefined;
+  const rawView = Array.isArray(resolvedSearchParams?.view)
+    ? resolvedSearchParams?.view[0]
+    : resolvedSearchParams?.view;
+  const view = rawView === "list" ? "list" : "bento";
+  let registry: { items?: RegistryItem[] };
+  const hideScrollbarStyles = `
+    html {
+      scrollbar-width: none;
+      -ms-overflow-style: none;
+    }
+    html::-webkit-scrollbar {
+      display: none;
+    }
+  `;
+
+  try {
+    registry = JSON.parse(readFileSync(registryPath, "utf-8"));
+  } catch {
+    return (
+      <div
+        className="min-h-svh bg-white"
+        style={{ paddingRight: "calc(100vw - 100%)" }}
+      >
+        <style>{hideScrollbarStyles}</style>
+        <div className="mx-auto flex w-full max-w-4xl flex-col gap-8 px-4 py-10 sm:px-6">
+          <header className="rounded-2xl border border-zinc-300 bg-white p-8">
+            <h1 className="text-3xl font-semibold tracking-tight text-zinc-900 sm:text-4xl">
+              Custom Registry
+            </h1>
+            <p className="mt-2 text-sm text-zinc-600">registry.json not found.</p>
+          </header>
+          <p className="rounded-2xl border border-dashed border-zinc-300 bg-white p-6 text-sm text-zinc-600">
+            Add a <code className="font-mono text-zinc-900">registry.json</code>{" "}
+            file to render your component previews in this page.
+          </p>
         </div>
-      </main>
+      </div>
+    );
+  }
+
+  const items = registry.items || [];
+  const components = items.filter(
+    (i) => i.type === "registry:ui" || i.type === "registry:block"
+  );
+  const hooks = items.filter((i) => i.type === "registry:hook");
+  const componentEntries = components.flatMap((item) => {
+    const Component = Registry[
+      toPascalCase(item.name) as keyof typeof Registry
+    ] as React.ComponentType<Record<string, unknown>> | undefined;
+
+    return Component ? [{ ...item, Component }] : [];
+  });
+
+  return (
+    <div
+      className="min-h-svh bg-white"
+      style={{ paddingRight: "calc(100vw - 100%)" }}
+    >
+      <style>{hideScrollbarStyles}</style>
+      <div className="mx-auto flex w-full max-w-6xl flex-col gap-8 px-4 py-10 sm:px-6">
+        <header className="rounded-2xl border border-zinc-300 bg-white p-6 sm:p-8">
+          <p className="text-xs uppercase tracking-[0.2em] text-zinc-500">
+            Registry Preview
+          </p>
+          <div className="mt-3 flex flex-wrap items-end justify-between gap-5">
+            <div>
+              <h1 className="text-3xl font-semibold tracking-tight text-zinc-900 sm:text-4xl">
+                Custom Registry
+              </h1>
+              <p className="mt-2 max-w-2xl text-sm text-zinc-600">
+                Preview your shadcn registry components in two layouts: a bold
+                bento grid and a compact list.
+              </p>
+            </div>
+            <div className="relative grid w-[220px] grid-cols-2 rounded-full border border-zinc-300 bg-white p-1">
+              <span
+                aria-hidden="true"
+                className={[
+                  "pointer-events-none absolute bottom-1 left-1 top-1 w-[calc(50%-4px)] rounded-full bg-zinc-900 transition-transform duration-300 ease-out",
+                  view === "list" ? "translate-x-full" : "translate-x-0",
+                ].join(" ")}
+              />
+              <Link
+                href="?view=bento"
+                className={
+                  view === "bento"
+                    ? "relative z-10 rounded-full px-3 py-1.5 text-center text-xs font-medium text-white"
+                    : "relative z-10 rounded-full px-3 py-1.5 text-center text-xs font-medium text-zinc-700"
+                }
+              >
+                Bento View
+              </Link>
+              <Link
+                href="?view=list"
+                className={
+                  view === "list"
+                    ? "relative z-10 rounded-full px-3 py-1.5 text-center text-xs font-medium text-white"
+                    : "relative z-10 rounded-full px-3 py-1.5 text-center text-xs font-medium text-zinc-700"
+                }
+              >
+                List View
+              </Link>
+            </div>
+          </div>
+          <div className="mt-5 flex flex-wrap gap-2 text-xs">
+            <span className="rounded-full border border-zinc-300 bg-white px-3 py-1 text-zinc-700">
+              {componentEntries.length} Components
+            </span>
+            <span className="rounded-full border border-zinc-300 bg-white px-3 py-1 text-zinc-700">
+              {hooks.length} Hooks
+            </span>
+            <span className="rounded-full border border-zinc-300 bg-white px-3 py-1 text-zinc-700">
+              View: {view === "bento" ? "Bento Grid" : "List"}
+            </span>
+          </div>
+        </header>
+
+        <main className="flex flex-col gap-6 pb-10">
+          {componentEntries.length === 0 ? (
+            <p className="rounded-2xl border border-dashed border-zinc-300 bg-white p-6 text-sm text-zinc-600">
+              No components or blocks in registry yet.
+            </p>
+          ) : view === "bento" ? (
+            <section className="grid auto-rows-[minmax(210px,auto)] gap-4 md:grid-cols-3">
+              {componentEntries.map((item, index) => (
+                <article
+                  key={item.name}
+                  className={[
+                    "group flex flex-col rounded-2xl border border-zinc-300 bg-white p-5 transition duration-300",
+                    getBentoSpan(index),
+                  ].join(" ")}
+                >
+                  <div className="mb-4 flex items-center justify-between gap-2">
+                    <h2 className="text-sm font-medium uppercase tracking-[0.16em] text-zinc-600">
+                      {formatTitle(item.name)}
+                    </h2>
+                    <span className="rounded-full bg-zinc-900 px-2 py-1 text-[10px] uppercase tracking-[0.14em] text-white">
+                      {item.type === "registry:block" ? "Block" : "UI"}
+                    </span>
+                  </div>
+                  <div className="flex min-h-[150px] flex-1 items-center justify-center overflow-auto rounded-xl border border-zinc-200 bg-white p-5">
+                    <item.Component />
+                  </div>
+                </article>
+              ))}
+            </section>
+          ) : (
+            <section className="rounded-2xl border border-zinc-300 bg-white">
+              {componentEntries.map((item, index) => (
+                <article
+                  key={item.name}
+                  className={[
+                    "grid gap-4 p-5 transition duration-300 md:grid-cols-[minmax(180px,240px)_1fr]",
+                    index < componentEntries.length - 1
+                      ? "border-b border-zinc-200"
+                      : "",
+                  ].join(" ")}
+                >
+                  <div className="space-y-2">
+                    <p className="text-xs uppercase tracking-[0.16em] text-zinc-500">
+                      {item.type === "registry:block" ? "Block" : "UI"}
+                    </p>
+                    <h2 className="text-lg font-semibold tracking-tight text-zinc-900">
+                      {formatTitle(item.name)}
+                    </h2>
+                  </div>
+                  <div className="flex min-h-[130px] items-center justify-center overflow-auto rounded-xl border border-zinc-200 bg-white p-4">
+                    <item.Component />
+                  </div>
+                </article>
+              ))}
+            </section>
+          )}
+
+          {hooks.length > 0 && (
+            <section className="rounded-2xl border border-zinc-300 bg-white p-5 sm:p-6">
+              <h2 className="text-xs uppercase tracking-[0.16em] text-zinc-500">
+                Hooks
+              </h2>
+              <ul className="mt-4 grid gap-2 sm:grid-cols-2">
+                {hooks.map((h) => (
+                  <li
+                    key={h.name}
+                    className="rounded-xl border border-zinc-200 bg-white px-3 py-2 font-mono text-sm text-zinc-700"
+                  >
+                    {h.name}
+                  </li>
+                ))}
+              </ul>
+            </section>
+          )}
+        </main>
+      </div>
     </div>
-  )
+  );
 }

--- a/bin/templates/registry.json
+++ b/bin/templates/registry.json
@@ -6,7 +6,7 @@
     {
       "name": "example",
       "type": "registry:ui",
-      "dependencies": ["@radix-ui/react-slot"],
+      "dependencies": [],
       "registryDependencies": [],
       "files": [
         {

--- a/bin/templates/registry.json
+++ b/bin/templates/registry.json
@@ -4,13 +4,13 @@
   "homepage": "{{HOMEPAGE}}",
   "items": [
     {
-      "name": "button",
+      "name": "example",
       "type": "registry:ui",
       "dependencies": ["@radix-ui/react-slot"],
       "registryDependencies": [],
       "files": [
         {
-          "path": "registry/{{STYLE_NAME}}/ui/button.tsx",
+          "path": "registry/{{STYLE_NAME}}/ui/example.tsx",
           "type": "registry:ui"
         }
       ]


### PR DESCRIPTION
…component, add-block, create, remove-component, and remove-block scripts. Update .gitignore to include .DS_Store files. Revamp page template for improved registry component previews with layout options.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dynamic registry display on home page with bento grid and list view, view toggles, and component/hook counts
  * Components now include size variant options (default, small, large, icon) and updated starter component output

* **Chores**
  * Auto-generated registry export file added and regenerated when components/blocks change
  * Updated macOS metadata files to ignore list
  * Updated component scaffolding help text and starter template renamed to "example"
<!-- end of auto-generated comment: release notes by coderabbit.ai -->